### PR TITLE
chore: updated tested upto WP 5.8 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** astra addons export, import, settings, customizer settings, theme settings, theme options  
 **Stable tag:** 1.0.4  
 **Requires PHP:** 5.4  
-**Tested up to:** 5.7  
+**Tested up to:** 5.8 
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.4
 Tags: astra addons export, import, settings, customizer settings, theme settings, theme options
 Stable tag: 1.0.4
 Requires PHP: 5.4
-Tested up to: 5.7
+Tested up to: 5.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- This plugin is tested on WP 5.8 version and no issue was found.
- We able to import and export Astra customizer settings.
- Updated readme files tested upto versions.