### PR TITLE
WordPress 6.3 Compatibility For Astra Import Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** astra addons export, import, settings, customizer settings, theme settings, theme options  
 **Stable tag:** 1.0.7  
 **Requires PHP:** 5.4  
-**Tested up to:** 6.2  
+**Tested up to:** 6.3
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.4
 Tags: astra addons export, import, settings, customizer settings, theme settings, theme options
 Stable tag: 1.0.7
 Requires PHP: 5.4
-Tested up to: 6.2
+Tested up to: 6.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Summary
- Provided WordPress 6.3 Compatibility.

Changes Made
- Updated Readme "Tested Upto" version to 6.3

Testing
- Tested with Astra Theme.
- Checked all options if applying correctly on frontend.
- Checked for Pages and Posts.
