### PR TITLE
WP 6.4 compat with Astra import/export plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** astra addons export, import, settings, customizer settings, theme settings, theme options  
 **Stable tag:** 1.0.7  
 **Requires PHP:** 5.4  
-**Tested up to:** 6.3
+**Tested up to:** 6.4
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.4
 Tags: astra addons export, import, settings, customizer settings, theme settings, theme options
 Stable tag: 1.0.7
 Requires PHP: 5.4
-Tested up to: 6.3
+Tested up to: 6.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Summary

Provided WordPress 6.4 Compatibility.
Changes Made

Updated Readme "Tested Upto" version to 6.4
Testing

Tested with Astra Theme.
Checked all options if applying correctly on frontend.
Checked for Pages and Posts.